### PR TITLE
docs(README): update URL for website

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To start Jekyll run:
 ```bash
     jekyll serve -w
 ```
-Site will be available at http://127.0.0.1:4000/zeppelin/ or http://localhost:4000/zeppelin/ (on Windows)
+Site will be available at http://127.0.0.1:4000/ or http://localhost:4000/ (on Windows)
 
 **NOTE:** in this mode all changes to html and data files will be automatically regenerated, but after changing ```_config.yml``` you have to restart server.
 


### PR DESCRIPTION
The website is available at `http://127.0.0.1:4000/` and not at
`http://127.0.0.1:4000/zepellin`.